### PR TITLE
Avoid access-before-initialization type error

### DIFF
--- a/src/ChannelManager.php
+++ b/src/ChannelManager.php
@@ -20,7 +20,7 @@ class ChannelManager extends Component
     /**
      * @var ChannelInterface[]|null The channels
      */
-    private ?array $_channels;
+    private ?array $_channels = null;
 
     /**
      * Returns all the channels.


### PR DESCRIPTION
### Description

This fixes an error you’d bump into after installing the plugin and visiting an entry page (and probably other places):

> Typed property craft\applenews\ChannelManager::$_channels must not be accessed before initialization

Experienced with Craft 4.4.10.1 on both PHP 8.0.28 and 8.2.4.

This is because `ChannelManager::getChannels()` tries to access that value [right here](https://github.com/craftcms/apple-news/blob/main/src/ChannelManager.php#L33-L35).

Initializing `$_channels` with a `null` value avoids the error and does not appear to ruin anything.
