### PR TITLE
Fix another type error

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -26,7 +26,7 @@ abstract class Helper
      * @var HtmlConverter|null $_htmlConverter
      * @see htmlConverter()
      */
-    private static ?HtmlConverter $_htmlConverter;
+    private static ?HtmlConverter $_htmlConverter = null;
 
     /**
      * Formats a language ID into the format required by the Apple News API (e.g. "en" or "en_US").


### PR DESCRIPTION
### Description

I found another one! If you attempt to download an article preview, you’ll be greeted with this message:

> Typed static property craft\applenews\Helper::$_htmlConverter must not be accessed before initialization

And to answer your question: yes, I insist on finding these one at a time.

### Related issues

#22 