### PR TITLE
htmlConverter must not be accessed before initialization

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -335,7 +335,7 @@ abstract class Helper
      */
     protected static function htmlConverter(): HtmlConverter
     {
-        if (self::$_htmlConverter !== null) {
+        if (!empty(self::$_htmlConverter)) {
             return self::$_htmlConverter;
         }
 


### PR DESCRIPTION
### Description

checking if an unset static variable is false leads to error in PHP 8.1 and 8.2, switching to !empty will fix it.

### Related issues

https://github.com/craftcms/apple-news/issues/25